### PR TITLE
Integrate token minter standard

### DIFF
--- a/core/Move.toml
+++ b/core/Move.toml
@@ -5,23 +5,15 @@ authors = ["lay (Aladeen)"]
 
 [addresses]
 composable_token = "0xacf659101f2f39123e5c9ff5486100c78a84d2ab8319c52e3795aeb29ea8db3a"
+minter = '_'
 
 [dev-addresses]
+minter = "0x123"
 
-[dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "main"
-subdir = "aptos-move/framework/aptos-framework"
-
-[dependencies.AptosTokenObjects]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "main"
-subdir = "aptos-move/framework/aptos-token-objects"
-
-[dependencies.AptosToken]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "main"
-subdir = "aptos-move/framework/aptos-token"
+[dependencies.TokenMinter]
+git = 'https://github.com/aptos-labs/token-minter.git'
+rev = 'main'
+subdir = 'token-minter/'
 
 [dev-dependencies]
 

--- a/core/sources/studio.move
+++ b/core/sources/studio.move
@@ -261,7 +261,7 @@ module composable_token::studio {
     // Create a named composable token with no royalty
     public entry fun create_named_composable_token_with_no_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         name: String,
         uri: String,
@@ -297,7 +297,7 @@ module composable_token::studio {
     // Create a named composable token with royalty
     public entry fun create_named_composable_token_with_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         name: String,
         uri: String,
@@ -335,7 +335,7 @@ module composable_token::studio {
     // Create an indexed composable token with royalty 
     public entry fun create_indexed_composable_token_with_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         uri: String,
         royalty_numerator: u64,
@@ -372,7 +372,7 @@ module composable_token::studio {
     // Create an indexed composable token without royalty 
     public entry fun create_indexed_composable_token_with_no_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         uri: String,
         property_keys: vector<String>,
@@ -407,7 +407,7 @@ module composable_token::studio {
     // Create a named trait token with no royalty
     public entry fun create_named_trait_token_with_no_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         name: String,
         uri: String,
@@ -443,7 +443,7 @@ module composable_token::studio {
     // Create a named trait token with royalty
     public entry fun create_named_trait_token_with_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         name: String,
         uri: String,
@@ -474,7 +474,7 @@ module composable_token::studio {
     // Create an indexed trait token with royalty
     public entry fun create_indexed_trait_token_with_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         uri: String,
         royalty_numerator: u64,
@@ -511,7 +511,7 @@ module composable_token::studio {
     // Create an indexed trait token with royalty off
     public entry fun create_indexed_trait_token_with_no_royalty(
         signer_ref: &signer,
-        collection: String,
+        collection: Object<Collection>,
         description: String,
         uri: String,
         property_keys: vector<String>,
@@ -626,10 +626,10 @@ module composable_token::studio {
     // Directly transfer a token to a user.
     public entry fun transfer_digital_asset<T: key>(
         owner: &signer, 
-        token_address: address,
+        token: Object<T>,
         new_owner_address: address,
     ) {
-        composable_token::transfer_token<T>(owner, token_address, new_owner_address);
+        composable_token::transfer_token(owner, token, new_owner_address);
     }
 
     // Directly transfer a token to a user.

--- a/core/tests/composables_test.move
+++ b/core/tests/composables_test.move
@@ -63,7 +63,7 @@ module composable_token::composable_token_test {
         
         let composable_constructor_ref = test_utils::create_named_composable_token_helper(
             creator,
-            COLLECTION_1_NAME, 
+            collection_obj,
             COMPOSABLE_1_NAME
         );
 
@@ -80,11 +80,11 @@ module composable_token::composable_token_test {
             COLLECTION_1_NAME, 
             option::some(100)
         );
-        // let collection_obj = object::object_from_constructor_ref<Collection>(&collection_constructor_ref);
+        let collection_obj = object::object_from_constructor_ref<Collection>(&collection_constructor_ref);
         
         let trait_constructor_ref = test_utils::create_named_trait_token_helper(
             creator,
-            COLLECTION_1_NAME,
+            collection_obj,
             TRAIT_1_NAME
         );
 
@@ -102,16 +102,17 @@ module composable_token::composable_token_test {
             COLLECTION_1_NAME, 
             option::some(100)
         );
+        let collection_obj = object::object_from_constructor_ref<Collection>(&collection_constructor_ref);
         
         let composable_constructor_ref = test_utils::create_named_composable_token_helper(
             creator,
-            COLLECTION_1_NAME, 
+            collection_obj,
             COMPOSABLE_1_NAME
         );
 
         let trait_constructor_ref = test_utils::create_named_trait_token_helper(
             creator,
-            COLLECTION_1_NAME,
+            collection_obj,
             TRAIT_1_NAME
         );
 
@@ -142,29 +143,29 @@ module composable_token::composable_token_test {
             COLLECTION_1_NAME, 
             option::some(100)
         );
+        let collection_obj_1 = object::object_from_constructor_ref(&collection_1_constructor_ref);
 
         let collection_2_constructor_ref = test_utils::create_collection_helper<FixedSupply>(
             creator,
             COLLECTION_2_NAME, 
             option::some(100)
         );
+        let collection_obj_2 = object::object_from_constructor_ref(&collection_2_constructor_ref);
         
         let composable_constructor_ref = test_utils::create_named_composable_token_helper(
             creator,
-            COLLECTION_2_NAME, 
+            collection_obj_1,
             COMPOSABLE_1_NAME
         );
 
         let trait_constructor_ref = test_utils::create_named_trait_token_helper(
             creator,
-            COLLECTION_1_NAME,
+            collection_obj_2,
             TRAIT_1_NAME
         );
 
         let composable_obj = object::object_from_constructor_ref<Composable>(&composable_constructor_ref);
         let trait_obj = object::object_from_constructor_ref<Trait>(&trait_constructor_ref);
-        let collection_1_obj = object::object_from_constructor_ref<Collection>(&collection_1_constructor_ref);
-        // let collection_2_obj = object::object_from_constructor_ref<Collection>(&collection_2_constructor_ref);
 
         // debug::print<address>(&object::owner<Collection>(collection_1_obj));
         // debug::print<address>(&object::owner<Composable>(composable_obj));
@@ -178,7 +179,7 @@ module composable_token::composable_token_test {
     }
 
     #[test(std = @0x1, alice = @0x123, bob = @0x456)]
-    // test transfer and equip; alice creates a token, transfers it to bob, and bob tries to equip a trait to it
+    // test transfer and equip; alice creates a token, transfers it to bob, and alice tries to equip a trait to it
     fun transfer_and_equip(std: signer, alice: &signer, bob: &signer) {
         test_utils::prepare_for_test(std);
 
@@ -187,40 +188,38 @@ module composable_token::composable_token_test {
             COLLECTION_1_NAME, 
             option::some(100)
         );
+        let collection_obj = object::object_from_constructor_ref(&collection_constructor_ref);
         
         let composable_constructor_ref = test_utils::create_named_composable_token_helper(
             alice,
-            COLLECTION_1_NAME, 
+            collection_obj,
             COMPOSABLE_1_NAME
         );
+        let composable_obj = object::object_from_constructor_ref(&composable_constructor_ref);
 
         let trait_constructor_ref = test_utils::create_named_trait_token_helper(
             alice,
-            COLLECTION_1_NAME,
+            collection_obj,
             TRAIT_1_NAME
         );
-
-        let composable_obj = object::object_from_constructor_ref<Composable>(&composable_constructor_ref);
-        let trait_obj = object::object_from_constructor_ref<Trait>(&trait_constructor_ref);
-        // let collection_obj = object::object_from_constructor_ref<Collection>(&collection_constructor_ref);
+        let trait_obj = object::object_from_constructor_ref(&trait_constructor_ref);
 
         // transfer composable to bob
-        let composable_token_addr = object::object_address(&composable_obj);
-        let trait_token_addr = object::object_address(&trait_obj);
-
-        composable_token::transfer_token<Composable>(alice, composable_token_addr, signer::address_of(bob));
+        composable_token::transfer_token<Composable>(alice, composable_obj, signer::address_of(bob));
         // TODO: check that transfer is successful
         // TODO: check events are emited correctly
 
         // transfer trait to bob
-        composable_token::transfer_token<Trait>(alice, trait_token_addr, signer::address_of(bob));
+        composable_token::transfer_token<Trait>(alice, trait_obj, signer::address_of(bob));
 
         // TODO: check that transfer is successful
         // TODO: check events are emited correctly
         
-        // bob equip trait to composable
+        // bob equip trait to composable - bob cannot do this as alice is the creator of the token's collection
         let uri_after_equipping_trait = string::utf8(b"URI after equipping trait");
-        composable_token::equip_trait(bob, composable_obj, trait_obj, uri_after_equipping_trait);
+
+        // alice can only call equip_trait, as alice is the creator of the token's collection
+        composable_token::equip_trait(alice, composable_obj, trait_obj, uri_after_equipping_trait);
         // TODO: check that the trait is equipped correctly
         // TODO: check events are emited correctly
     }

--- a/core/tests/test_utils.move
+++ b/core/tests/test_utils.move
@@ -117,11 +117,11 @@ module composable_token::test_utils {
     }
 
     // create a composable
-    public fun create_named_composable_token_helper(signer_ref: &signer, collection_name: vector<u8>, composable_name: vector<u8>): object::ConstructorRef {
+    public fun create_named_composable_token_helper(signer_ref: &signer, collection: Object<Collection>, composable_name: vector<u8>): object::ConstructorRef {
         // let type = string::utf8(b"");   // Composable token does not have a type
         composable_token::create_token<Composable, Named>(
             signer_ref,
-            string::utf8(collection_name),
+            collection,
             string::utf8(COMPOSABLE_DESCRIPTION),
             string::utf8(composable_name),
             string::utf8(b""),
@@ -136,10 +136,10 @@ module composable_token::test_utils {
     }
 
     // create a trait
-    public fun create_named_trait_token_helper(signer_ref: &signer, collection_name: vector<u8>, trait_name: vector<u8>): object::ConstructorRef {
+    public fun create_named_trait_token_helper(signer_ref: &signer, collection: Object<Collection>, trait_name: vector<u8>): object::ConstructorRef {
         composable_token::create_token<Trait, Named>(
             signer_ref,
-            string::utf8(collection_name),
+            collection,
             string::utf8(TRAIT_DESCRIPTION),
             string::utf8(trait_name),
             string::utf8(b""),


### PR DESCRIPTION
##  Description
With the new AIP72 Token Minter standard, aim is to use this standard to enable ease of digital asset development, whilst adopting best practices within the Aptos ecosystem.

### Changes
- Creating Collection and Token refs via token minter.
- Using token minter provided functions to update token metadata, such as uri etc.

## Design
Only the collection owner can change token URI's, name, description etc. This derives from the token minter standard.

#### Token Minter Repo: https://github.com/aptos-labs/token-minter